### PR TITLE
Hide API key and add server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+API_KEY=your_openweather_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+node_modules/

--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@
 Weather dashboard which colects and displays data of the weather conditions on the day and gives a 5 day forecast 
 
 ## Installation
-Just run the html code or open the page through this link https://andresparraarze.github.io/mega-dash/
+1. Ensure Node.js is installed. (Running `npm install` is optional as there are no external dependencies.)
+2. Copy `.env.example` to `.env` and add your OpenWeather API key.
+3. Start the server with `npm start`.
+4. Open `http://localhost:3000` in your browser.
 
 ## Usage
-Just write the name of the city where you want toget the weather information from as seen on the screenshot
+Start the server and enter a city name in the search bar to retrieve the weather information.
 
 ![Screenshot 2022-07-03 190905](https://user-images.githubusercontent.com/82328303/177060312-d9706080-6e05-4cb6-ac3c-0e8baee6cfbd.png)
 

--- a/assets/index.js
+++ b/assets/index.js
@@ -23,12 +23,11 @@ let d5 = new Date();
 d5.setDate(d5.getDate()+5);
 const [month5, day5, year5] = [d5.getMonth() + 1, d5.getDate(), d5.getFullYear()];
 
-//Weather Key and API fetch for today
+//Fetch weather data from the server
 let weather = {
-apiKey: "37b31aa04e6b58aa1fe7f3e2b71cf214",
     fetchWeather: function (city) {
     fetch(
-    "https://api.openweathermap.org/data/2.5/weather?q=" + city + "&units=metric&appid=" + this.apiKey
+    "/weather?city=" + city
     )
     .then((response) => {
         if (!response.ok) {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "mega-dash",
+  "version": "1.0.0",
+  "description": "Weather dashboard",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {}
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,88 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+// Load environment variables from .env if present
+const envPath = path.join(__dirname, '.env');
+if (fs.existsSync(envPath)) {
+  const envData = fs.readFileSync(envPath, 'utf8').split(/\r?\n/);
+  for (const line of envData) {
+    const match = line.match(/^([^#=]+)=?(.*)$/);
+    if (match) {
+      const key = match[1].trim();
+      const value = match[2].trim();
+      if (key) {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+const PORT = process.env.PORT || 3000;
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.json': 'application/json',
+};
+
+function serveStatic(req, res) {
+  let filePath = path.join(__dirname, req.url === '/' ? '/index.html' : req.url);
+  if (!filePath.startsWith(__dirname)) {
+    res.writeHead(403);
+    return res.end();
+  }
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      return res.end('Not found');
+    }
+    const ext = path.extname(filePath);
+    const type = mimeTypes[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  });
+}
+
+async function handleWeather(req, res, urlObj) {
+  const city = urlObj.searchParams.get('city');
+  if (!city) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    return res.end(JSON.stringify({ error: 'City parameter is required' }));
+  }
+  const apiKey = process.env.API_KEY;
+  if (!apiKey) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    return res.end(JSON.stringify({ error: 'API key not configured' }));
+  }
+  try {
+    const apiUrl = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&units=metric&appid=${apiKey}`;
+    const response = await fetch(apiUrl);
+    if (!response.ok) {
+      res.writeHead(response.status, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ error: 'Error fetching weather' }));
+    }
+    const data = await response.json();
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(data));
+  } catch (err) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Internal server error' }));
+  }
+}
+
+const server = http.createServer((req, res) => {
+  const urlObj = new URL(req.url, `http://${req.headers.host}`);
+  if (urlObj.pathname === '/weather') {
+    return handleWeather(req, res, urlObj);
+  }
+  serveStatic(req, res);
+});
+
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- make the weather server dependency-free using built-in Node modules
- clean up stray prompt text in `assets/index.js`
- update README install notes

## Testing
- `node server.js` *(starts server)*
- `npm test` *(fails: Missing script)*