### PR TITLE
Add geolocation-based weather

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -39,6 +39,20 @@ let weather = {
         .then((data) => this.displayWeather(data));
     },
 
+    fetchWeatherByCoords: function (lat, lon) {
+    fetch(
+    `/weather?lat=${lat}&lon=${lon}`
+    )
+    .then((response) => {
+        if (!response.ok) {
+            alert("No weather found.");
+            throw new Error("No weather found.");
+        }
+            return response.json();
+        })
+        .then((data) => this.displayWeather(data));
+    },
+
 //Data retrieved and displayed from the API and the html for today
     displayWeather: function (data) {
         const { name } = data;
@@ -115,5 +129,16 @@ document
             weather.search();
             }
 });
-      
-weather.fetchWeather("Toronto");    
+
+if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(
+        (position) => {
+            weather.fetchWeatherByCoords(position.coords.latitude, position.coords.longitude);
+        },
+        () => {
+            weather.fetchWeather("Toronto");
+        }
+    );
+} else {
+    weather.fetchWeather("Toronto");
+}

--- a/server.js
+++ b/server.js
@@ -50,9 +50,13 @@ function serveStatic(req, res) {
 
 async function handleWeather(req, res, urlObj) {
   const city = urlObj.searchParams.get('city');
-  if (!city) {
+  const lat = urlObj.searchParams.get('lat');
+  const lon = urlObj.searchParams.get('lon');
+  if (!city && !(lat && lon)) {
     res.writeHead(400, { 'Content-Type': 'application/json' });
-    return res.end(JSON.stringify({ error: 'City parameter is required' }));
+    return res.end(
+      JSON.stringify({ error: 'City or lat/lon parameters are required' })
+    );
   }
   const apiKey = process.env.API_KEY;
   if (!apiKey) {
@@ -60,7 +64,12 @@ async function handleWeather(req, res, urlObj) {
     return res.end(JSON.stringify({ error: 'API key not configured' }));
   }
   try {
-    const apiUrl = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&units=metric&appid=${apiKey}`;
+    let apiUrl;
+    if (lat && lon) {
+      apiUrl = `https://api.openweathermap.org/data/2.5/weather?lat=${encodeURIComponent(lat)}&lon=${encodeURIComponent(lon)}&units=metric&appid=${apiKey}`;
+    } else {
+      apiUrl = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&units=metric&appid=${apiKey}`;
+    }
     const response = await fetch(apiUrl);
     if (!response.ok) {
       res.writeHead(response.status, { 'Content-Type': 'application/json' });


### PR DESCRIPTION
## Summary
- allow the server /weather endpoint to accept latitude and longitude
- fetch weather using coordinates or city name
- add `fetchWeatherByCoords` helper on the frontend
- get device geolocation on page load and fetch weather automatically

## Testing
- `node --check server.js`
- `node --check assets/index.js`
