### PR TITLE
Update forecast dates to show sequential days

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -2,26 +2,13 @@
 const date = new Date();
 const [month, day, year] = [date.getMonth() + 1, date.getDate(), date.getFullYear()];
 
-//Future dates
-let d1 = new Date();
-d1.setDate(d1.getDate()+1);
-const [month1, day1, year1] = [d1.getMonth() + 1, d1.getDate(), d1.getFullYear()];
-
-let d2 = new Date();
-d2.setDate(d2.getDate()+2);
-const [month2, day2, year2] = [d2.getMonth() + 1, d2.getDate(), d2.getFullYear()];
-
-let d3 = new Date();
-d3.setDate(d3.getDate()+3);
-const [month3, day3, year3] = [d3.getMonth() + 1, d3.getDate(), d3.getFullYear()];
-
-let d4 = new Date();
-d4.setDate(d4.getDate()+4);
-const [month4, day4, year4] = [d4.getMonth() + 1, d4.getDate(), d4.getFullYear()];
-
-let d5 = new Date();
-d5.setDate(d5.getDate()+5);
-const [month5, day5, year5] = [d5.getMonth() + 1, d5.getDate(), d5.getFullYear()];
+// Future dates for the next five forecast cards
+const futureDates = [];
+for (let i = 1; i <= 5; i++) {
+    const d = new Date();
+    d.setDate(d.getDate() + i);
+    futureDates.push([d.getMonth() + 1, d.getDate(), d.getFullYear()]);
+}
 
 //Fetch weather data from the server
 let weather = {
@@ -128,17 +115,14 @@ let weather = {
         const dates = Object.keys(daily).sort().slice(0, 5);
         dates.forEach((d, idx) => {
             const forecast = daily[d];
-            const dateObj = new Date(forecast.dt_txt);
-            const m = dateObj.getMonth() + 1;
-            const day = dateObj.getDate();
-            const y = dateObj.getFullYear();
+            const [mDisp, dayDisp, yDisp] = futureDates[idx];
             const icon = forecast.weather[0].icon;
             const desc = forecast.weather[0].description;
             const temp = forecast.main.temp;
             const humidity = forecast.main.humidity;
             const speed = forecast.wind.speed;
             const i = idx + 2;
-            document.querySelector(`.date${i}`).innerText = `${m}/${day}/${y}`;
+            document.querySelector(`.date${i}`).innerText = `${mDisp}/${dayDisp}/${yDisp}`;
             document.querySelector(`.icon${i}`).src = `http://openweathermap.org/img/wn/${icon}.png`;
             document.querySelector(`.description${i}`).innerText = desc;
             document.querySelector(`.temp${i}`).innerText = `${temp}°C`;


### PR DESCRIPTION
## Summary
- calculate upcoming dates once
- show sequential dates on forecast cards using the new dates array

## Testing
- `npm start` *(fails: Server listening on port 3000, then manually stopped)*