### PR TITLE
Fix future dates in forecast cards

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -2,13 +2,7 @@
 const date = new Date();
 const [month, day, year] = [date.getMonth() + 1, date.getDate(), date.getFullYear()];
 
-// Future dates for the next five forecast cards
-const futureDates = [];
-for (let i = 1; i <= 5; i++) {
-    const d = new Date();
-    d.setDate(d.getDate() + i);
-    futureDates.push([d.getMonth() + 1, d.getDate(), d.getFullYear()]);
-}
+
 
 //Fetch weather data from the server
 let weather = {
@@ -115,7 +109,10 @@ let weather = {
         const dates = Object.keys(daily).sort().slice(0, 5);
         dates.forEach((d, idx) => {
             const forecast = daily[d];
-            const [mDisp, dayDisp, yDisp] = futureDates[idx];
+            const dateObj = new Date(forecast.dt * 1000);
+            const mDisp = dateObj.getMonth() + 1;
+            const dayDisp = dateObj.getDate();
+            const yDisp = dateObj.getFullYear();
             const icon = forecast.weather[0].icon;
             const desc = forecast.weather[0].description;
             const temp = forecast.main.temp;

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
         <!--second card for upcoming weather-->
         <div class="card2" >
             <div class="more-weather">
-                <h2 class="date2">06/27/2022</h2>
+                <h2 class="date2">00/00/0000</h2>
                 <div class="flex">
                     <img src="https://openweathermap.org/img/wn/04n.png" alt="" class="icon2" />
                     <div class="description2">Rainy</div>
@@ -56,7 +56,7 @@
     <!--third card for upcomming weather-->
         <div class="card2">
             <div class="more-weather">
-                <h2 class="date3">06/27/2022</h2>
+                <h2 class="date3">00/00/0000</h2>
             <div class="flex">
                 <img src="https://openweathermap.org/img/wn/04n.png" alt="" class="icon3" />
                 <div class="description3">Rainy</div>
@@ -70,7 +70,7 @@
     <!--fourth card for upcomming weather-->
     <div class="card2">
         <div class="more-weather">
-            <h2 class="date4">06/27/2022</h2>
+            <h2 class="date4">00/00/0000</h2>
             <div class="flex">
                 <img src="https://openweathermap.org/img/wn/04n.png" alt="" class="icon4" />
                 <div class="description4">Rainy</div>
@@ -84,7 +84,7 @@
     <!--fifth card for upcomming weather-->
     <div class="card2">
         <div class="more-weather">
-            <h2 class="date5">06/27/2022</h2>
+            <h2 class="date5">00/00/0000</h2>
             <div class="flex">
                 <img src="https://openweathermap.org/img/wn/04n.png" alt="" class="icon5" />
                 <div class="description5">Rainy</div>
@@ -98,7 +98,7 @@
     <!--sixth card for upcomming weather-->
     <div class="card2">
         <div class="more-weather">
-            <h2 class="date6">06/27/2022</h2>
+            <h2 class="date6">00/00/0000</h2>
             <div class="flex">
                 <img src="https://openweathermap.org/img/wn/04n.png" alt="" class="icon6" />
                 <div class="description6">Rainy</div>


### PR DESCRIPTION
## Summary
- fix sequential forecast dates in the frontend
- use forecast data timestamps directly instead of preset dates

## Testing
- `node --test test/server.test.js`